### PR TITLE
feat: Auth Interceptor, resolver 추가

### DIFF
--- a/src/main/java/kr/co/conceptbe/auth/config/AuthConfig.java
+++ b/src/main/java/kr/co/conceptbe/auth/config/AuthConfig.java
@@ -1,14 +1,26 @@
 package kr.co.conceptbe.auth.config;
 
+import java.util.List;
+import kr.co.conceptbe.auth.presentation.AuthInterceptor;
+import kr.co.conceptbe.auth.presentation.MandatoryJwtArgumentResolver;
 import kr.co.conceptbe.auth.presentation.OauthServerTypeConverter;
+import kr.co.conceptbe.auth.presentation.OptionalJwtArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class AuthConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final MandatoryJwtArgumentResolver mandatoryJwtArgumentResolver;
+    private final OptionalJwtArgumentResolver optionalJwtArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -28,5 +40,16 @@ public class AuthConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new OauthServerTypeConverter());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(mandatoryJwtArgumentResolver);
+        resolvers.add(optionalJwtArgumentResolver);
     }
 }

--- a/src/main/java/kr/co/conceptbe/auth/exception/TokenMissingException.java
+++ b/src/main/java/kr/co/conceptbe/auth/exception/TokenMissingException.java
@@ -8,6 +8,6 @@ import kr.co.conceptbe.common.exception.ErrorCode;
 public class TokenMissingException extends ConceptBeException {
 
     public TokenMissingException() {
-        super(new ErrorCode(UNAUTHORIZED, "토큰이 필요합니다."));
+        super(new ErrorCode(UNAUTHORIZED, "토큰이 누락되었습니다."));
     }
 }

--- a/src/main/java/kr/co/conceptbe/auth/exception/TokenMissingException.java
+++ b/src/main/java/kr/co/conceptbe/auth/exception/TokenMissingException.java
@@ -1,0 +1,13 @@
+package kr.co.conceptbe.auth.exception;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+import kr.co.conceptbe.common.exception.ConceptBeException;
+import kr.co.conceptbe.common.exception.ErrorCode;
+
+public class TokenMissingException extends ConceptBeException {
+
+    public TokenMissingException() {
+        super(new ErrorCode(UNAUTHORIZED, "토큰이 필요합니다."));
+    }
+}

--- a/src/main/java/kr/co/conceptbe/auth/presentation/AuthInterceptor.java
+++ b/src/main/java/kr/co/conceptbe/auth/presentation/AuthInterceptor.java
@@ -23,7 +23,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         HttpServletResponse response,
         Object handler
     ) {
-        if (CorsUtils.isCorsRequest(request) || hasNotAuthorization(request)) {
+        if (CorsUtils.isPreFlightRequest(request) || hasNotAuthorization(request)) {
             return true;
         }
         String accessToken = BearerTokenExtractor.extract(request);

--- a/src/main/java/kr/co/conceptbe/auth/presentation/AuthInterceptor.java
+++ b/src/main/java/kr/co/conceptbe/auth/presentation/AuthInterceptor.java
@@ -1,0 +1,37 @@
+package kr.co.conceptbe.auth.presentation;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.conceptbe.auth.support.BearerTokenExtractor;
+import kr.co.conceptbe.auth.support.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) {
+        if (CorsUtils.isCorsRequest(request) || hasNotAuthorization(request)) {
+            return true;
+        }
+        String accessToken = BearerTokenExtractor.extract(request);
+        jwtProvider.validateParseJws(accessToken);
+        return true;
+    }
+
+    private boolean hasNotAuthorization(HttpServletRequest request) {
+        return request.getHeader(AUTHORIZATION) == null;
+    }
+}

--- a/src/main/java/kr/co/conceptbe/auth/presentation/MandatoryJwtArgumentResolver.java
+++ b/src/main/java/kr/co/conceptbe/auth/presentation/MandatoryJwtArgumentResolver.java
@@ -1,0 +1,47 @@
+package kr.co.conceptbe.auth.presentation;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.conceptbe.auth.exception.TokenMissingException;
+import kr.co.conceptbe.auth.presentation.dto.AuthCredentials;
+import kr.co.conceptbe.auth.support.BearerTokenExtractor;
+import kr.co.conceptbe.auth.support.JwtProvider;
+import kr.co.conceptbe.common.auth.Auth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class MandatoryJwtArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class)
+                && parameter.getParameterType().equals(AuthCredentials.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (request.getHeader(AUTHORIZATION) == null) {
+            throw new TokenMissingException();
+        }
+        String accessToken = BearerTokenExtractor.extract(request);
+
+        String id = jwtProvider.getPayload(accessToken);
+        return new AuthCredentials(Long.valueOf(id));
+    }
+}

--- a/src/main/java/kr/co/conceptbe/auth/presentation/OptionalJwtArgumentResolver.java
+++ b/src/main/java/kr/co/conceptbe/auth/presentation/OptionalJwtArgumentResolver.java
@@ -1,0 +1,46 @@
+package kr.co.conceptbe.auth.presentation;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.conceptbe.auth.presentation.dto.AuthCredentials;
+import kr.co.conceptbe.auth.support.BearerTokenExtractor;
+import kr.co.conceptbe.auth.support.JwtProvider;
+import kr.co.conceptbe.common.auth.OptionalAuth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class OptionalJwtArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(OptionalAuth.class)
+                && parameter.getParameterType().equals(AuthCredentials.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (request.getHeader(AUTHORIZATION) == null) {
+            return null;
+        }
+        String accessToken = BearerTokenExtractor.extract(request);
+
+        String id = jwtProvider.getPayload(accessToken);
+        return new AuthCredentials(Long.valueOf(id));
+    }
+}

--- a/src/main/java/kr/co/conceptbe/auth/presentation/dto/AuthCredentials.java
+++ b/src/main/java/kr/co/conceptbe/auth/presentation/dto/AuthCredentials.java
@@ -1,0 +1,6 @@
+package kr.co.conceptbe.auth.presentation.dto;
+
+public record AuthCredentials(
+        Long id
+) {
+}

--- a/src/main/java/kr/co/conceptbe/auth/support/BearerTokenExtractor.java
+++ b/src/main/java/kr/co/conceptbe/auth/support/BearerTokenExtractor.java
@@ -1,0 +1,27 @@
+package kr.co.conceptbe.auth.support;
+
+import static lombok.AccessLevel.PRIVATE;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.conceptbe.auth.exception.TokenInvalidException;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class BearerTokenExtractor {
+
+    private static final String BEARER_TYPE = "Bearer ";
+    private static final String BEARER_JWT_REGEX = "^Bearer [A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$";
+
+    public static String extract(HttpServletRequest request) {
+        String authorization = request.getHeader(AUTHORIZATION);
+        validate(authorization);
+        return authorization.replace(BEARER_TYPE, "").trim();
+    }
+
+    private static void validate(String authorization) {
+        if (!authorization.matches(BEARER_JWT_REGEX)) {
+            throw new TokenInvalidException();
+        }
+    }
+}

--- a/src/main/java/kr/co/conceptbe/common/auth/Auth.java
+++ b/src/main/java/kr/co/conceptbe/common/auth/Auth.java
@@ -1,0 +1,11 @@
+package kr.co.conceptbe.common.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/kr/co/conceptbe/common/auth/OptionalAuth.java
+++ b/src/main/java/kr/co/conceptbe/common/auth/OptionalAuth.java
@@ -1,0 +1,12 @@
+package kr.co.conceptbe.common.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptionalAuth {
+
+}


### PR DESCRIPTION
## 📄 Summary
- #3 
- #5

Resolver를 통해 나오게 되는 결과값은 AuthCredentials이고 안에 id만 존재합니다. resolver단에서 repository에 접근하는게 별로인거 같아서 유저 식별값인 id만 가지도록 했습니다.

로그인을 해야 사용할 수 있는 api는 @Auth 애노테이션, Optional인 경우에는 @OptionalAuth로 사용하시면 될 것 같습니다!



## 🙋🏻 More
> 
