### PR TITLE
feat: 로그인 시 간단 정보 추가 및 My page 프로필 정보 조회 API 추가

### DIFF
--- a/src/main/java/kr/co/conceptbe/auth/application/OauthService.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/OauthService.java
@@ -1,25 +1,26 @@
 package kr.co.conceptbe.auth.application;
 
 import java.util.List;
-import kr.co.conceptbe.auth.application.dto.OauthMemberResponse;
-import kr.co.conceptbe.auth.domain.client.OauthMemberClientHandler;
-import kr.co.conceptbe.auth.infra.oauth.dto.OauthMemberInformation;
-import kr.co.conceptbe.auth.domain.authcode.AuthCodeRequestUrlProviderHandler;
-import kr.co.conceptbe.auth.presentation.dto.TokenResponse;
-import kr.co.conceptbe.auth.support.JwtProvider;
-import kr.co.conceptbe.common.entity.domain.persistence.PurposeRepository;
-import kr.co.conceptbe.member.application.MemberService;
+import kr.co.conceptbe.auth.application.dto.AuthMemberInformation;
+import kr.co.conceptbe.auth.application.dto.AuthResponse;
 import kr.co.conceptbe.auth.application.dto.DetailSkillResponse;
 import kr.co.conceptbe.auth.application.dto.FindSignUpResponse;
 import kr.co.conceptbe.auth.application.dto.MainSkillResponse;
+import kr.co.conceptbe.auth.application.dto.OauthMemberResponse;
 import kr.co.conceptbe.auth.application.dto.PurposeResponse;
 import kr.co.conceptbe.auth.application.dto.SignUpRequest;
+import kr.co.conceptbe.auth.domain.authcode.AuthCodeRequestUrlProviderHandler;
+import kr.co.conceptbe.auth.domain.client.OauthMemberClientHandler;
+import kr.co.conceptbe.auth.infra.oauth.dto.OauthMemberInformation;
+import kr.co.conceptbe.auth.support.JwtProvider;
+import kr.co.conceptbe.common.entity.domain.persistence.PurposeRepository;
+import kr.co.conceptbe.member.application.MemberService;
 import kr.co.conceptbe.member.domain.Member;
 import kr.co.conceptbe.member.domain.MemberPurpose;
 import kr.co.conceptbe.member.domain.MemberSkillCategory;
-import kr.co.conceptbe.member.persistence.MemberRepository;
 import kr.co.conceptbe.member.domain.OauthId;
 import kr.co.conceptbe.member.domain.OauthServerType;
+import kr.co.conceptbe.member.persistence.MemberRepository;
 import kr.co.conceptbe.purpose.domain.Purpose;
 import kr.co.conceptbe.skill.domain.SkillCategory;
 import kr.co.conceptbe.skill.domain.SkillCategoryRepository;
@@ -54,15 +55,22 @@ public class OauthService {
         return new OauthMemberResponse(isMember, oauthMemberInformation);
     }
 
-    public String login(String oauthId, OauthServerType oauthServerType) {
+    public AuthResponse login(String oauthId, OauthServerType oauthServerType) {
         Member member = memberRepository.getByOauthId(new OauthId(oauthId, oauthServerType));
-        return jwtProvider.createAccessToken(member.getId());
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+        return new AuthResponse(
+            accessToken,
+            new AuthMemberInformation(member.getId(), member.getNickname(), member.getProfileImageUrl())
+        );
     }
 
-    public TokenResponse signUp(SignUpRequest signUpRequest) {
+    public AuthResponse signUp(SignUpRequest signUpRequest) {
         Member member = saveMember(signUpRequest);
         String accessToken = jwtProvider.createAccessToken(member.getId());
-        return new TokenResponse(accessToken);
+        return new AuthResponse(
+            accessToken,
+            new AuthMemberInformation(member.getId(), member.getNickname(), member.getProfileImageUrl())
+        );
     }
 
     private Member saveMember(SignUpRequest signUpRequest) {

--- a/src/main/java/kr/co/conceptbe/auth/application/dto/AuthMemberInformation.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/dto/AuthMemberInformation.java
@@ -1,0 +1,8 @@
+package kr.co.conceptbe.auth.application.dto;
+
+public record AuthMemberInformation(
+    Long id,
+    String nickname,
+    String profileImageUrl
+) {
+}

--- a/src/main/java/kr/co/conceptbe/auth/application/dto/AuthResponse.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/dto/AuthResponse.java
@@ -1,0 +1,7 @@
+package kr.co.conceptbe.auth.application.dto;
+
+public record AuthResponse(
+    String accessToken,
+    AuthMemberInformation authMemberInformation
+) {
+}

--- a/src/main/java/kr/co/conceptbe/auth/presentation/OauthController.java
+++ b/src/main/java/kr/co/conceptbe/auth/presentation/OauthController.java
@@ -4,9 +4,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import kr.co.conceptbe.auth.application.OauthService;
-import kr.co.conceptbe.auth.application.dto.OauthMemberResponse;
-import kr.co.conceptbe.auth.presentation.dto.TokenResponse;
+import kr.co.conceptbe.auth.application.dto.AuthResponse;
 import kr.co.conceptbe.auth.application.dto.FindSignUpResponse;
+import kr.co.conceptbe.auth.application.dto.OauthMemberResponse;
 import kr.co.conceptbe.auth.application.dto.SignUpRequest;
 import kr.co.conceptbe.member.domain.OauthServerType;
 import lombok.RequiredArgsConstructor;
@@ -44,18 +44,18 @@ public class OauthController {
     }
 
     @GetMapping("/oauth/{oauthServerType}/login")
-    ResponseEntity<TokenResponse> login(
+    ResponseEntity<AuthResponse> login(
         @PathVariable OauthServerType oauthServerType,
         @RequestParam("oauthId") String oauthId
     ) {
-        String accessToken = oauthService.login(oauthId, oauthServerType);
-        return ResponseEntity.ok(new TokenResponse(accessToken));
+        AuthResponse authResponse = oauthService.login(oauthId, oauthServerType);
+        return ResponseEntity.ok(authResponse);
     }
 
     @PostMapping("/sign-up")
-    ResponseEntity<TokenResponse> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
-        TokenResponse tokenResponse = oauthService.signUp(signUpRequest);
-        return ResponseEntity.ok(tokenResponse);
+    ResponseEntity<AuthResponse> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
+        AuthResponse authResponse = oauthService.signUp(signUpRequest);
+        return ResponseEntity.ok(authResponse);
     }
 
     @GetMapping("/sign-up")

--- a/src/main/java/kr/co/conceptbe/member/application/MemberService.java
+++ b/src/main/java/kr/co/conceptbe/member/application/MemberService.java
@@ -1,5 +1,9 @@
 package kr.co.conceptbe.member.application;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.co.conceptbe.member.application.dto.GetMemberProfileResponse;
+import kr.co.conceptbe.member.domain.Member;
 import kr.co.conceptbe.member.exception.AlreadyExistsNicknameException;
 import kr.co.conceptbe.member.persistence.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,5 +21,31 @@ public class MemberService {
         if (memberRepository.existsByNickname(nickname)) {
             throw new AlreadyExistsNicknameException(nickname);
         }
+    }
+
+    public GetMemberProfileResponse getMemberProfileBy(Long id) {
+        Member member = memberRepository.getById(id);
+        return new GetMemberProfileResponse(
+            member.getProfileImageUrl(),
+            member.getNickname(),
+            member.getMainSkill().getName(),
+            member.getWorkingPlace(),
+            member.getWorkingPlace(),
+            member.getIntroduce(),
+            mapToMemberSkills(member),
+            mapToMemberPurposes(member)
+        );
+    }
+
+    private List<String> mapToMemberPurposes(Member member) {
+        return member.getPurposes().stream()
+            .map(purpose -> purpose.getPurpose().getName())
+            .collect(Collectors.toList());
+    }
+
+    private List<String> mapToMemberSkills(Member member) {
+        return member.getSkills().stream()
+            .map(skill -> skill.getSkillCategory().getName())
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/kr/co/conceptbe/member/application/dto/GetMemberProfileResponse.java
+++ b/src/main/java/kr/co/conceptbe/member/application/dto/GetMemberProfileResponse.java
@@ -1,0 +1,15 @@
+package kr.co.conceptbe.member.application.dto;
+
+import java.util.List;
+
+public record GetMemberProfileResponse(
+    String profileImageUrl,
+    String nickname,
+    String mainSkill,
+    String livingPlace,
+    String workingPlace,
+    String introduction,
+    List<String> skills,
+    List<String> joinPurposes
+) {
+}

--- a/src/main/java/kr/co/conceptbe/member/controller/MemberController.java
+++ b/src/main/java/kr/co/conceptbe/member/controller/MemberController.java
@@ -1,23 +1,34 @@
 package kr.co.conceptbe.member.controller;
 
 import kr.co.conceptbe.member.application.MemberService;
+import kr.co.conceptbe.member.application.dto.GetMemberProfileResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/members")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/members/nickname/{nickname}")
+    @GetMapping("/nickname/{nickname}")
     ResponseEntity<Void> checkDuplicatedNickName(
         @PathVariable String nickname
     ) {
         memberService.validateDuplicatedNickName(nickname);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{id}")
+    ResponseEntity<GetMemberProfileResponse> getMemberProfile(
+        @PathVariable Long id
+    ) {
+        GetMemberProfileResponse memberProfileResponse = memberService.getMemberProfileBy(id);
+        return ResponseEntity.ok(memberProfileResponse);
     }
 }

--- a/src/main/java/kr/co/conceptbe/member/domain/Member.java
+++ b/src/main/java/kr/co/conceptbe/member/domain/Member.java
@@ -44,8 +44,6 @@ import lombok.NoArgsConstructor;
 )
 public class Member extends BaseTimeEntity {
 
-    //TODO 패키지 변경
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/test/java/kr/co/conceptbe/auth/application/OauthServiceTest.java
+++ b/src/test/java/kr/co/conceptbe/auth/application/OauthServiceTest.java
@@ -1,16 +1,16 @@
 package kr.co.conceptbe.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
+import kr.co.conceptbe.auth.application.dto.AuthResponse;
 import kr.co.conceptbe.auth.application.dto.SignUpRequest;
 import kr.co.conceptbe.auth.application.dto.SignUpSkillRequest;
-import kr.co.conceptbe.auth.presentation.dto.TokenResponse;
+import kr.co.conceptbe.auth.fixture.AuthFixture;
 import kr.co.conceptbe.auth.support.JwtProvider;
 import kr.co.conceptbe.common.entity.domain.persistence.PurposeRepository;
 import kr.co.conceptbe.member.domain.Member;
-import kr.co.conceptbe.auth.fixture.AuthFixture;
 import kr.co.conceptbe.member.persistence.MemberRepository;
 import kr.co.conceptbe.purpose.domain.Purpose;
 import kr.co.conceptbe.skill.domain.SkillCategory;
@@ -58,10 +58,10 @@ class OauthServiceTest {
         );
 
         //when
-        TokenResponse tokenResponse = oauthService.signUp(signUpRequest);
+        AuthResponse authResponse = oauthService.signUp(signUpRequest);
 
         //then
-        String memberId = jwtProvider.getPayload(tokenResponse.accessToken());
+        String memberId = jwtProvider.getPayload(authResponse.accessToken());
         Member member = memberRepository.getById(Long.valueOf(memberId));
         List<String> skillLevels = mapToSkillLevels(member);
         List<String> skillNames = mapToSkillNames(member);
@@ -70,7 +70,10 @@ class OauthServiceTest {
             () -> assertThat(member.getMainSkill().getName()).isEqualTo("개발"),
             () -> assertThat(skillLevels).contains("상", "하"),
             () -> assertThat(skillNames).contains("BE", "FE"),
-            () -> assertThat(purposeNames).contains("창업")
+            () -> assertThat(purposeNames).contains("창업"),
+            () -> assertThat(authResponse.authMemberInformation().id()).isEqualTo(member.getId()),
+            () -> assertThat(authResponse.authMemberInformation().nickname()).isEqualTo(member.getNickname()),
+            () -> assertThat(authResponse.authMemberInformation().profileImageUrl()).isEqualTo(member.getProfileImageUrl())
         );
     }
 


### PR DESCRIPTION
## 📄 Summary
- #14 

- accessToken 줄 때 유저 정보도 넘겨주도록 수정
- 프로필 정보 조회 (My Page)
  - 프로필 사진
  - 닉네임
  - 대표 스킬
  - 사는곳
  - 회사명
  - 자기소개
  - 스킬
  - 관심영역

## 🙋🏻 More
> 나머지 MyPage API들도 같이 올리려다가 해당 부분이 필요한 거 같아서 따로 올립니다!
