### PR TITLE
스킬 중복선택 방지 추가

### DIFF
--- a/src/main/java/kr/co/conceptbe/auth/application/OauthService.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/OauthService.java
@@ -9,12 +9,11 @@ import kr.co.conceptbe.auth.application.dto.MainSkillResponse;
 import kr.co.conceptbe.auth.application.dto.OauthMemberResponse;
 import kr.co.conceptbe.auth.application.dto.PurposeResponse;
 import kr.co.conceptbe.auth.application.dto.SignUpRequest;
-import kr.co.conceptbe.auth.application.dto.SkillRequest;
+import kr.co.conceptbe.auth.application.dto.SkillRequests;
 import kr.co.conceptbe.auth.domain.authcode.AuthCodeRequestUrlProviderHandler;
 import kr.co.conceptbe.auth.domain.client.OauthMemberClientHandler;
 import kr.co.conceptbe.auth.infra.oauth.dto.OauthMemberInformation;
 import kr.co.conceptbe.auth.support.JwtProvider;
-import kr.co.conceptbe.purpose.domain.persistence.PurposeRepository;
 import kr.co.conceptbe.member.application.MemberService;
 import kr.co.conceptbe.member.domain.Member;
 import kr.co.conceptbe.member.domain.MemberPurpose;
@@ -23,6 +22,7 @@ import kr.co.conceptbe.member.domain.OauthId;
 import kr.co.conceptbe.member.domain.OauthServerType;
 import kr.co.conceptbe.member.persistence.MemberRepository;
 import kr.co.conceptbe.purpose.domain.Purpose;
+import kr.co.conceptbe.purpose.domain.persistence.PurposeRepository;
 import kr.co.conceptbe.skill.domain.SkillCategory;
 import kr.co.conceptbe.skill.domain.SkillCategoryRepository;
 import kr.co.conceptbe.skill.domain.SkillLevel;
@@ -92,7 +92,8 @@ public class OauthService {
     }
 
     private List<MemberSkillCategory> mapToMemberSkills(SignUpRequest signUpRequest, Member member) {
-        return signUpRequest.skills().stream()
+        SkillRequests skillRequests = signUpRequest.skills();
+        return skillRequests.skills().stream()
             .map(skillRequest -> {
                 SkillCategory skill = skillCategoryRepository.getById(skillRequest.skillId());
                 return new MemberSkillCategory(member, skill, SkillLevel.from(skillRequest.level()));

--- a/src/main/java/kr/co/conceptbe/auth/application/OauthService.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/OauthService.java
@@ -9,6 +9,7 @@ import kr.co.conceptbe.auth.application.dto.MainSkillResponse;
 import kr.co.conceptbe.auth.application.dto.OauthMemberResponse;
 import kr.co.conceptbe.auth.application.dto.PurposeResponse;
 import kr.co.conceptbe.auth.application.dto.SignUpRequest;
+import kr.co.conceptbe.auth.application.dto.SkillRequest;
 import kr.co.conceptbe.auth.domain.authcode.AuthCodeRequestUrlProviderHandler;
 import kr.co.conceptbe.auth.domain.client.OauthMemberClientHandler;
 import kr.co.conceptbe.auth.infra.oauth.dto.OauthMemberInformation;

--- a/src/main/java/kr/co/conceptbe/auth/application/dto/SignUpRequest.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/dto/SignUpRequest.java
@@ -30,7 +30,7 @@ public record SignUpRequest(
     @Schema(description = "세부 스킬 리스트")
     @NotNull(message = "스킬은 빈 값일 수 없습니다.")
     @Size(min = 1, max = 3, message = "스킬은 1개 이상 3개이하로 선택해야 됩니다.")
-    List<SkillRequest> skills,
+    SkillRequests skills,
 
     @Schema(description = "가입 목적 리스트")
     @NotNull(message = "가입목적은 빈 값일 수 없습니다.")

--- a/src/main/java/kr/co/conceptbe/auth/application/dto/SignUpRequest.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/dto/SignUpRequest.java
@@ -30,7 +30,7 @@ public record SignUpRequest(
     @Schema(description = "세부 스킬 리스트")
     @NotNull(message = "스킬은 빈 값일 수 없습니다.")
     @Size(min = 1, max = 3, message = "스킬은 1개 이상 3개이하로 선택해야 됩니다.")
-    List<SignUpSkillRequest> skills,
+    List<SkillRequest> skills,
 
     @Schema(description = "가입 목적 리스트")
     @NotNull(message = "가입목적은 빈 값일 수 없습니다.")

--- a/src/main/java/kr/co/conceptbe/auth/application/dto/SkillRequest.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/dto/SkillRequest.java
@@ -1,6 +1,6 @@
 package kr.co.conceptbe.auth.application.dto;
 
-public record SignUpSkillRequest(
+public record SkillRequest(
     Long skillId,
     String level
 ) {

--- a/src/main/java/kr/co/conceptbe/auth/application/dto/SkillRequests.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/dto/SkillRequests.java
@@ -8,9 +8,8 @@ public record SkillRequests(
     List<SkillRequest> skills
 ) {
 
-    public SkillRequests(List<SkillRequest> skills) {
+    public SkillRequests {
         checkDuplicatedSkillCategory(skills);
-        this.skills = skills;
     }
 
     private void checkDuplicatedSkillCategory(List<SkillRequest> skills) {

--- a/src/main/java/kr/co/conceptbe/auth/application/dto/SkillRequests.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/dto/SkillRequests.java
@@ -1,0 +1,28 @@
+package kr.co.conceptbe.auth.application.dto;
+
+import java.util.List;
+import java.util.Objects;
+import kr.co.conceptbe.skill.exception.DuplicatedSkillCategoryException;
+
+public record SkillRequests(
+    List<SkillRequest> skills
+) {
+
+    public SkillRequests(List<SkillRequest> skills) {
+        checkDuplicatedSkillCategory(skills);
+        this.skills = skills;
+    }
+
+    private void checkDuplicatedSkillCategory(List<SkillRequest> skills) {
+        for (int standard = 0; standard < skills.size(); standard++) {
+            for (int other = 0; other < skills.size(); other++) {
+                if (standard == other) {
+                    continue;
+                }
+                if (Objects.equals(skills.get(standard).skillId(), skills.get(other).skillId())) {
+                    throw new DuplicatedSkillCategoryException();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/kr/co/conceptbe/auth/application/dto/UpdateMemberProfileRequest.java
+++ b/src/main/java/kr/co/conceptbe/auth/application/dto/UpdateMemberProfileRequest.java
@@ -25,7 +25,7 @@ public record UpdateMemberProfileRequest(
     @Schema(description = "세부 스킬 리스트")
     @NotNull(message = "스킬은 빈 값일 수 없습니다.")
     @Size(min = 1, max = 3, message = "스킬은 1개 이상 3개이하로 선택해야 됩니다.")
-    List<SignUpSkillRequest> skills,
+    List<SkillRequest> skills,
 
     @Schema(description = "가입 목적 리스트")
     @NotNull(message = "가입목적은 빈 값일 수 없습니다.")

--- a/src/main/java/kr/co/conceptbe/skill/exception/DuplicatedSkillCategoryException.java
+++ b/src/main/java/kr/co/conceptbe/skill/exception/DuplicatedSkillCategoryException.java
@@ -1,0 +1,13 @@
+package kr.co.conceptbe.skill.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import kr.co.conceptbe.common.exception.ConceptBeException;
+import kr.co.conceptbe.common.exception.ErrorCode;
+
+public class DuplicatedSkillCategoryException extends ConceptBeException {
+
+    public DuplicatedSkillCategoryException() {
+        super(new ErrorCode(BAD_REQUEST, "중복된 스킬을 가질 수 없습니다."));
+    }
+}

--- a/src/test/java/kr/co/conceptbe/auth/application/OauthServiceTest.java
+++ b/src/test/java/kr/co/conceptbe/auth/application/OauthServiceTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.util.List;
 import kr.co.conceptbe.auth.application.dto.AuthResponse;
 import kr.co.conceptbe.auth.application.dto.SignUpRequest;
-import kr.co.conceptbe.auth.application.dto.SignUpSkillRequest;
+import kr.co.conceptbe.auth.application.dto.SkillRequest;
 import kr.co.conceptbe.auth.fixture.AuthFixture;
 import kr.co.conceptbe.auth.support.JwtProvider;
 import kr.co.conceptbe.purpose.domain.persistence.PurposeRepository;
@@ -51,8 +51,8 @@ class OauthServiceTest {
         SignUpRequest signUpRequest = AuthFixture.createSignUpRequest(
             mainSkill.getId(),
             List.of(
-                new SignUpSkillRequest(beDetailSkill.getId(), SkillLevel.HIGH.getName()),
-                new SignUpSkillRequest(feDetailSkill.getId(), SkillLevel.LOW.getName())
+                new SkillRequest(beDetailSkill.getId(), SkillLevel.HIGH.getName()),
+                new SkillRequest(feDetailSkill.getId(), SkillLevel.LOW.getName())
             ),
             purpose.getId()
         );

--- a/src/test/java/kr/co/conceptbe/auth/application/OauthServiceTest.java
+++ b/src/test/java/kr/co/conceptbe/auth/application/OauthServiceTest.java
@@ -7,12 +7,13 @@ import java.util.List;
 import kr.co.conceptbe.auth.application.dto.AuthResponse;
 import kr.co.conceptbe.auth.application.dto.SignUpRequest;
 import kr.co.conceptbe.auth.application.dto.SkillRequest;
+import kr.co.conceptbe.auth.application.dto.SkillRequests;
 import kr.co.conceptbe.auth.fixture.AuthFixture;
 import kr.co.conceptbe.auth.support.JwtProvider;
-import kr.co.conceptbe.purpose.domain.persistence.PurposeRepository;
 import kr.co.conceptbe.member.domain.Member;
 import kr.co.conceptbe.member.persistence.MemberRepository;
 import kr.co.conceptbe.purpose.domain.Purpose;
+import kr.co.conceptbe.purpose.domain.persistence.PurposeRepository;
 import kr.co.conceptbe.skill.domain.SkillCategory;
 import kr.co.conceptbe.skill.domain.SkillCategoryRepository;
 import kr.co.conceptbe.skill.domain.SkillLevel;
@@ -50,10 +51,10 @@ class OauthServiceTest {
         Purpose purpose = purposeRepository.save(Purpose.from("창업"));
         SignUpRequest signUpRequest = AuthFixture.createSignUpRequest(
             mainSkill.getId(),
-            List.of(
+            new SkillRequests(List.of(
                 new SkillRequest(beDetailSkill.getId(), SkillLevel.HIGH.getName()),
                 new SkillRequest(feDetailSkill.getId(), SkillLevel.LOW.getName())
-            ),
+            )),
             purpose.getId()
         );
 

--- a/src/test/java/kr/co/conceptbe/auth/fixture/AuthFixture.java
+++ b/src/test/java/kr/co/conceptbe/auth/fixture/AuthFixture.java
@@ -1,16 +1,16 @@
 package kr.co.conceptbe.auth.fixture;
 
 import java.util.List;
+import kr.co.conceptbe.auth.application.dto.SignUpRequest;
+import kr.co.conceptbe.auth.application.dto.SkillRequests;
 import kr.co.conceptbe.member.domain.OauthServerType;
 import kr.co.conceptbe.member.domain.Region;
-import kr.co.conceptbe.auth.application.dto.SignUpRequest;
-import kr.co.conceptbe.auth.application.dto.SkillRequest;
 
 public class AuthFixture {
 
     public static SignUpRequest createSignUpRequest(
         Long mainSkillId,
-        List<SkillRequest> skills,
+        SkillRequests skills,
         Long purposeId
     ) {
         return new SignUpRequest("nickname",

--- a/src/test/java/kr/co/conceptbe/auth/fixture/AuthFixture.java
+++ b/src/test/java/kr/co/conceptbe/auth/fixture/AuthFixture.java
@@ -4,13 +4,13 @@ import java.util.List;
 import kr.co.conceptbe.member.domain.OauthServerType;
 import kr.co.conceptbe.member.domain.Region;
 import kr.co.conceptbe.auth.application.dto.SignUpRequest;
-import kr.co.conceptbe.auth.application.dto.SignUpSkillRequest;
+import kr.co.conceptbe.auth.application.dto.SkillRequest;
 
 public class AuthFixture {
 
     public static SignUpRequest createSignUpRequest(
         Long mainSkillId,
-        List<SignUpSkillRequest> skills,
+        List<SkillRequest> skills,
         Long purposeId
     ) {
         return new SignUpRequest("nickname",


### PR DESCRIPTION
## 📄 Summary
- close: #53 

회원가입이나 프로필 수정 둘 다 사용되기 때문에 범용적으로 쓰기 위해 SignUpSkillRequest에서 SkillRequest로 dto 이름을 바꿨습니다.

그리고 중복 방지 로직을 한 곳에서 처리해주기 위해 일급 컬렉션 비슷하게 List<SkillRequest>를 보유한 SkillRequests를 새로 추가 했습니다. 

## 🙋🏻 More
> 
