### PR TITLE
[refactor] 필터링 조건으로 상관없음을 선택하면 온/오프라인 모두 가져올 수 있도록한다.

### DIFF
--- a/src/main/java/kr/co/conceptbe/idea/application/request/FilteringRequest.java
+++ b/src/main/java/kr/co/conceptbe/idea/application/request/FilteringRequest.java
@@ -1,11 +1,12 @@
 package kr.co.conceptbe.idea.application.request;
 
 import java.util.List;
+import kr.co.conceptbe.idea.domain.vo.CooperationWay;
 
 public record FilteringRequest(
         List<Long> branchIds,
         List<Long> purposeIds,
-        String cooperationWay,
+        CooperationWay cooperationWay,
         Long recruitmentPlace,
         List<Long> skillCategoryIds
 ) {

--- a/src/main/java/kr/co/conceptbe/idea/domain/persistence/IdeaRepositoryCustomImpl.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/persistence/IdeaRepositoryCustomImpl.java
@@ -74,12 +74,13 @@ public class IdeaRepositoryCustomImpl implements IdeaRepositoryCustom {
     }
 
     private BooleanExpression cooperationWayEqual(CooperationWay cooperationWay) {
-        if (cooperationWay == CooperationWay.NO_MATTER) {
+        if (Objects.isNull(cooperationWay) || cooperationWay == CooperationWay.NO_MATTER) {
             return null;
         }
 
         return idea.cooperationWay
-            .eq(CooperationWay.from(cooperationWay.getValue()));
+            .eq(cooperationWay)
+            .or(idea.cooperationWay.eq(CooperationWay.NO_MATTER));
     }
 
     private BooleanExpression recruitmentPlaceEqual(Long regionId) {

--- a/src/main/java/kr/co/conceptbe/idea/domain/persistence/IdeaRepositoryCustomImpl.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/persistence/IdeaRepositoryCustomImpl.java
@@ -4,7 +4,6 @@ import static kr.co.conceptbe.idea.domain.QIdea.idea;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import io.micrometer.common.util.StringUtils;
 import java.util.List;
 import java.util.Objects;
 import kr.co.conceptbe.idea.application.request.FilteringRequest;
@@ -74,13 +73,13 @@ public class IdeaRepositoryCustomImpl implements IdeaRepositoryCustom {
             .id.in(purposeIds);
     }
 
-    private BooleanExpression cooperationWayEqual(String cooperationWay) {
-        if (StringUtils.isEmpty(cooperationWay)) {
+    private BooleanExpression cooperationWayEqual(CooperationWay cooperationWay) {
+        if (cooperationWay == CooperationWay.NO_MATTER) {
             return null;
         }
 
         return idea.cooperationWay
-            .eq(CooperationWay.from(cooperationWay));
+            .eq(CooperationWay.from(cooperationWay.getValue()));
     }
 
     private BooleanExpression recruitmentPlaceEqual(Long regionId) {

--- a/src/main/java/kr/co/conceptbe/idea/presentation/IdeaController.java
+++ b/src/main/java/kr/co/conceptbe/idea/presentation/IdeaController.java
@@ -17,6 +17,7 @@ import kr.co.conceptbe.idea.application.request.IdeaUpdateRequest;
 import kr.co.conceptbe.idea.application.response.BestIdeaResponse;
 import kr.co.conceptbe.idea.application.response.FindIdeaWriteResponse;
 import kr.co.conceptbe.idea.application.response.IdeaResponse;
+import kr.co.conceptbe.idea.domain.vo.CooperationWay;
 import kr.co.conceptbe.idea.dto.IdeaDetailResponse;
 import kr.co.conceptbe.idea.dto.IdeaHitResponse;
 import kr.co.conceptbe.idea.presentation.doc.IdeaApi;
@@ -97,7 +98,7 @@ public class IdeaController implements IdeaApi {
         FilteringRequest filteringRequest = new FilteringRequest(
             branchIds,
             purposeIds,
-            cooperationWay,
+            CooperationWay.from(cooperationWay),
             region,
             skillCategoryIds
         );
@@ -121,7 +122,7 @@ public class IdeaController implements IdeaApi {
         FilteringRequest filteringRequest = new FilteringRequest(
             branchIds,
             purposeIds,
-            cooperationWay,
+            CooperationWay.from(cooperationWay),
             region,
             skillCategoryIds
         );

--- a/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
+++ b/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
@@ -30,6 +30,7 @@ import kr.co.conceptbe.region.domain.presentation.RegionRepository;
 import kr.co.conceptbe.skill.domain.SkillCategory;
 import kr.co.conceptbe.skill.domain.SkillCategoryRepository;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/src/test/java/kr/co/conceptbe/idea/fixture/IdeaFixture.java
+++ b/src/test/java/kr/co/conceptbe/idea/fixture/IdeaFixture.java
@@ -3,6 +3,7 @@ package kr.co.conceptbe.idea.fixture;
 import java.util.List;
 import kr.co.conceptbe.branch.domain.Branch;
 import kr.co.conceptbe.idea.domain.Idea;
+import kr.co.conceptbe.idea.domain.vo.CooperationWay;
 import kr.co.conceptbe.member.domain.Member;
 import kr.co.conceptbe.purpose.domain.Purpose;
 import kr.co.conceptbe.region.domain.Region;
@@ -26,6 +27,26 @@ public class IdeaFixture {
                 branch,
                 purpose,
                 skillCategory
+        );
+    }
+
+    public static Idea createIdeaByCooperationWay(
+        String cooperationWay,
+        Region region,
+        List<Branch> branch,
+        List<Purpose> purpose,
+        List<SkillCategory> skillCategory,
+        Member member
+    ) {
+        return Idea.of(
+            "title",
+            "introduce".repeat(2),
+            cooperationWay,
+            region,
+            member,
+            branch,
+            purpose,
+            skillCategory
         );
     }
 


### PR DESCRIPTION
## 📄 Summary
>
#56 해당 이슈 작업했습니다.

작업한 부분은

- 상관없음을 선택했을 때, `상관없음, 온라인, 오프라인` 모두 불러올 수 있도록 하게끔 했구요.
- `온라인, 오프라인`을 선택했을 때에도 상관없음을 불러올 수 있도록 수정했어요.
- 아 그리고 추가적으로, 제가 FilteringRequest 에 illegal 한 CooperationWay(협업방식)이 들어가는 것을 안막아놨더라구요? 그래서 이전에 만들어놨던 VO 로 감싸서 해결해주었습니다.

이 부분의 동작이 궁금하시다면 추가된 테스트를 보시면 이해가 쉬우실 것 같습니다.

## 🙋🏻 More
> 

작업한 부분에서 조금 마음에 걸리는 것이 있어요. 이게 위 동작을 Repository 딴에서 처리하면 되게 깔끔하게 처리가 되는 것 같거든요?(지금 제 짧은 생각으로는) 하지만, 이게 비즈니스 로직이 Repository 딴까지 전파가 되고 있는 것인가? 그러면 안티하지 않나? 라는 생각이 듭니다.

어떻게 생각하시나요? 그리고 해결 방법이 있다면 알려주시면 감사할 것 같아요!