### PR TITLE
[refactor] 외래키로 인한 게시글 삭제 불가를 해결한다.

### DIFF
--- a/src/main/java/kr/co/conceptbe/bookmark/Bookmark.java
+++ b/src/main/java/kr/co/conceptbe/bookmark/Bookmark.java
@@ -37,7 +37,7 @@ public class Bookmark extends BaseTimeEntity implements Serializable {
         this.idea = idea;
     }
 
-    public static Bookmark ofWithIdeaAndMember(Idea idea, Member member) {
+    public static Bookmark createBookmarkAssociatedWithIdeaAndMember(Idea idea, Member member) {
         BookmarkID bookmarkID = new BookmarkID(member.getId(), idea.getId());
         Bookmark bookmark = new Bookmark(bookmarkID, member, idea);
         idea.addBookmark(bookmark);

--- a/src/main/java/kr/co/conceptbe/bookmark/Bookmark.java
+++ b/src/main/java/kr/co/conceptbe/bookmark/Bookmark.java
@@ -1,12 +1,11 @@
 package kr.co.conceptbe.bookmark;
 
-import java.io.Serializable;
-
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
+import java.io.Serializable;
 import kr.co.conceptbe.common.entity.base.BaseTimeEntity;
 import kr.co.conceptbe.idea.domain.Idea;
 import kr.co.conceptbe.member.domain.Member;
@@ -36,6 +35,13 @@ public class Bookmark extends BaseTimeEntity implements Serializable {
         this.bookmarkID = bookmarkID;
         this.member = member;
         this.idea = idea;
+    }
+
+    public static Bookmark ofWithIdeaAndMember(Idea idea, Member member) {
+        BookmarkID bookmarkID = new BookmarkID(member.getId(), idea.getId());
+        Bookmark bookmark = new Bookmark(bookmarkID, member, idea);
+        idea.addBookmark(bookmark);
+        return bookmark;
     }
 
     public boolean isOwnerOfBookmark(Long tokenMemberId) {

--- a/src/main/java/kr/co/conceptbe/comment/Comment.java
+++ b/src/main/java/kr/co/conceptbe/comment/Comment.java
@@ -64,7 +64,16 @@ public class Comment extends BaseTimeEntity {
         this.deleted = false;
     }
 
-    public void addParentComment(Comment comment) { this.parentComment = comment; }
+    public static Comment ofWithIdeaAndCreator(String content, Comment parentComment,
+        Idea idea, Member creator) {
+        Comment comment = new Comment(content, parentComment, creator, idea);
+        idea.addComment(comment);
+        return comment;
+    }
+
+    public void addParentComment(Comment comment) {
+        this.parentComment = comment;
+    }
 
     public void addComment(Comment comment) {
         this.comments.add(comment);
@@ -82,9 +91,13 @@ public class Comment extends BaseTimeEntity {
         this.deleted = true;
     }
 
-    public int getLikesCount() { return likes.size(); }
+    public int getLikesCount() {
+        return likes.size();
+    }
 
-    public int getCommentsCount() { return comments.size(); }
+    public int getCommentsCount() {
+        return comments.size();
+    }
 
     public boolean isParentComment() {
         return this.parentComment == null;

--- a/src/main/java/kr/co/conceptbe/comment/Comment.java
+++ b/src/main/java/kr/co/conceptbe/comment/Comment.java
@@ -64,8 +64,12 @@ public class Comment extends BaseTimeEntity {
         this.deleted = false;
     }
 
-    public static Comment ofWithIdeaAndCreator(String content, Comment parentComment,
-        Idea idea, Member creator) {
+    public static Comment createCommentAssociatedWithIdeaAndCreator(
+        String content,
+        Comment parentComment,
+        Idea idea,
+        Member creator
+    ) {
         Comment comment = new Comment(content, parentComment, creator, idea);
         idea.addComment(comment);
         return comment;

--- a/src/main/java/kr/co/conceptbe/idea/application/IdeaService.java
+++ b/src/main/java/kr/co/conceptbe/idea/application/IdeaService.java
@@ -125,7 +125,7 @@ public class IdeaService {
         IdeaDetailResponse ideaDetailResponse = IdeaDetailResponse.of(tokenMemberId, idea);
 
         Member member = memberRepository.getById(tokenMemberId);
-        Hit hit = Hit.of(member, idea);
+        Hit hit = Hit.ofIdeaAndMember(idea, member);
         hitRepository.save(hit);
 
         return ideaDetailResponse;

--- a/src/main/java/kr/co/conceptbe/idea/domain/Hit.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/Hit.java
@@ -10,7 +10,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import kr.co.conceptbe.common.entity.base.BaseTimeEntity;
 import kr.co.conceptbe.member.domain.Member;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,7 +35,7 @@ public class Hit extends BaseTimeEntity {
         this.idea = idea;
     }
 
-    public static Hit of(Member member, Idea idea) {
+    public static Hit ofIdeaAndMember(Idea idea, Member member) {
         Hit hit = new Hit(member, idea);
         idea.addHit(hit);
         return hit;

--- a/src/main/java/kr/co/conceptbe/idea/domain/Idea.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/Idea.java
@@ -2,6 +2,7 @@ package kr.co.conceptbe.idea.domain;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -68,16 +69,16 @@ public class Idea extends BaseTimeEntity {
     @Embedded
     private IdeaSkillCategories skillCategories;
 
-    @OneToMany(mappedBy = "idea")
+    @OneToMany(mappedBy = "idea", cascade = {CascadeType.REMOVE})
     private final List<Hit> hits = new ArrayList<>();
 
-    @OneToMany(mappedBy = "idea")
+    @OneToMany(mappedBy = "idea", cascade = {CascadeType.REMOVE})
     private final List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "idea", orphanRemoval = true)
+    @OneToMany(mappedBy = "idea", orphanRemoval = true, cascade = {CascadeType.REMOVE})
     private final List<IdeaLike> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "idea")
+    @OneToMany(mappedBy = "idea", cascade = {CascadeType.REMOVE})
     private final List<Bookmark> bookmarks = new ArrayList<>();
 
     private Idea(

--- a/src/main/java/kr/co/conceptbe/idea/domain/IdeaLike.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/IdeaLike.java
@@ -37,7 +37,7 @@ public class IdeaLike extends BaseTimeEntity implements Serializable {
         this.idea = idea;
     }
 
-    public static IdeaLike ofWithIdeaAndMember(Idea idea, Member member) {
+    public static IdeaLike createIdeaLikeAssociatedWithIdeaAndMember(Idea idea, Member member) {
         IdeaLikeID ideaLikeID = new IdeaLikeID(member.getId(), idea.getId());
         IdeaLike ideaLike = new IdeaLike(ideaLikeID, member, idea);
         idea.addIdeaLikes(ideaLike);

--- a/src/main/java/kr/co/conceptbe/idea/domain/IdeaLike.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/IdeaLike.java
@@ -2,13 +2,12 @@ package kr.co.conceptbe.idea.domain;
 
 import static lombok.AccessLevel.PROTECTED;
 
-import java.io.Serializable;
-
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
+import java.io.Serializable;
 import kr.co.conceptbe.common.entity.base.BaseTimeEntity;
 import kr.co.conceptbe.member.domain.Member;
 import lombok.Getter;
@@ -36,6 +35,13 @@ public class IdeaLike extends BaseTimeEntity implements Serializable {
         this.ideaLikeID = ideaLikeID;
         this.member = member;
         this.idea = idea;
+    }
+
+    public static IdeaLike ofWithIdeaAndMember(Idea idea, Member member) {
+        IdeaLikeID ideaLikeID = new IdeaLikeID(member.getId(), idea.getId());
+        IdeaLike ideaLike = new IdeaLike(ideaLikeID, member, idea);
+        idea.addIdeaLikes(ideaLike);
+        return ideaLike;
     }
 
     public boolean isOwnerOfLike(Long tokenMemberId) {

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaBranches.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaBranches.java
@@ -19,7 +19,7 @@ public class IdeaBranches {
 
     private static final int IDEA_BRANCHES_SIZE_LOWER_BOUND_INCLUSIVE = 1;
 
-    @OneToMany(mappedBy = "idea", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "idea", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<IdeaBranch> ideaBranches;
 
     private IdeaBranches(List<IdeaBranch> ideaBranches) {
@@ -30,8 +30,8 @@ public class IdeaBranches {
         validateSize(branches);
 
         List<IdeaBranch> ideaBranches = branches.stream()
-                .map(branch -> IdeaBranch.of(idea, branch))
-                .toList();
+            .map(branch -> IdeaBranch.of(idea, branch))
+            .toList();
 
         return new IdeaBranches(ideaBranches);
     }

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaPurposes.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaPurposes.java
@@ -7,9 +7,9 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
 import java.util.List;
-import kr.co.conceptbe.purpose.domain.Purpose;
 import kr.co.conceptbe.idea.domain.Idea;
 import kr.co.conceptbe.idea.domain.IdeaPurpose;
+import kr.co.conceptbe.purpose.domain.Purpose;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,7 +20,7 @@ public class IdeaPurposes {
 
     private static final int IDEA_PURPOSES_SIZE_LOWER_BOUND_INCLUSIVE = 1;
 
-    @OneToMany(mappedBy = "idea", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "idea", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<IdeaPurpose> ideaPurposes;
 
     private IdeaPurposes(List<IdeaPurpose> ideaPurposes) {
@@ -31,8 +31,8 @@ public class IdeaPurposes {
         validateSize(purposes);
 
         List<IdeaPurpose> ideaPurposes = purposes.stream()
-                .map(purpose -> IdeaPurpose.of(idea, purpose))
-                .toList();
+            .map(purpose -> IdeaPurpose.of(idea, purpose))
+            .toList();
 
         return new IdeaPurposes(ideaPurposes);
     }

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaSkillCategories.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaSkillCategories.java
@@ -19,7 +19,7 @@ public class IdeaSkillCategories {
 
     private static final int IDEA_SKILL_CATEGORIES_SIZE_UPPER_BOUND_INCLUSIVE = 10;
 
-    @OneToMany(mappedBy = "idea", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "idea", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<IdeaSkillCategory> ideaSkillCategories;
 
     private IdeaSkillCategories(List<IdeaSkillCategory> ideaSkillCategories) {
@@ -30,8 +30,8 @@ public class IdeaSkillCategories {
         validateSize(skillCategories);
 
         List<IdeaSkillCategory> ideaSkillCategories = skillCategories.stream()
-                .map(skillCategory -> IdeaSkillCategory.of(idea, skillCategory))
-                .toList();
+            .map(skillCategory -> IdeaSkillCategory.of(idea, skillCategory))
+            .toList();
 
         return new IdeaSkillCategories(ideaSkillCategories);
     }

--- a/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
+++ b/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
@@ -265,14 +265,10 @@ class IdeaServiceTest {
         Region region = regionRepository.save(Region.from("BUSAN"));
         Member member = memberRepository.save(MemberFixture.createMember());
         Idea idea = ideaRepository.save(createValidIdea(region, member));
-        // 댓글, 대댓글
         Comment parentComment = Comment.ofWithIdeaAndCreator("댓글", null, idea, member);
         Comment.ofWithIdeaAndCreator("대댓글", parentComment, idea, member);
-        // 좋아요
         IdeaLike.ofWithIdeaAndMember(idea, member);
-        // 조회수
-        Hit.of(member, idea);
-        // 북마크
+        Hit.ofIdeaAndMember(idea, member);
         Bookmark.ofWithIdeaAndMember(idea, member);
 
         // when

--- a/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
+++ b/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
@@ -9,13 +9,17 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import kr.co.conceptbe.auth.presentation.dto.AuthCredentials;
+import kr.co.conceptbe.bookmark.Bookmark;
 import kr.co.conceptbe.branch.domain.Branch;
 import kr.co.conceptbe.branch.domain.persistense.BranchRepository;
+import kr.co.conceptbe.comment.Comment;
 import kr.co.conceptbe.idea.application.request.IdeaRequest;
 import kr.co.conceptbe.idea.application.request.IdeaUpdateRequest;
 import kr.co.conceptbe.idea.application.response.FindIdeaWriteResponse;
 import kr.co.conceptbe.idea.application.response.SkillCategoryResponse;
+import kr.co.conceptbe.idea.domain.Hit;
 import kr.co.conceptbe.idea.domain.Idea;
+import kr.co.conceptbe.idea.domain.IdeaLike;
 import kr.co.conceptbe.idea.domain.persistence.IdeaRepository;
 import kr.co.conceptbe.idea.fixture.IdeaFixture;
 import kr.co.conceptbe.member.domain.Member;
@@ -30,7 +34,6 @@ import kr.co.conceptbe.region.domain.presentation.RegionRepository;
 import kr.co.conceptbe.skill.domain.SkillCategory;
 import kr.co.conceptbe.skill.domain.SkillCategoryRepository;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -247,6 +250,30 @@ class IdeaServiceTest {
         Region region = regionRepository.save(Region.from("BUSAN"));
         Member member = memberRepository.save(MemberFixture.createMember());
         Idea idea = ideaRepository.save(createValidIdea(region, member));
+
+        // when
+        ideaService.deleteIdea(new AuthCredentials(member.getId()), idea.getId());
+        Optional<Idea> deletedIdea = ideaRepository.findById(idea.getId());
+
+        // then
+        assertThat(deletedIdea).isEmpty();
+    }
+
+    @Test
+    void 게시글과_연관된_데이터가_존재하더라도_삭제에_성공한다() {
+        // given
+        Region region = regionRepository.save(Region.from("BUSAN"));
+        Member member = memberRepository.save(MemberFixture.createMember());
+        Idea idea = ideaRepository.save(createValidIdea(region, member));
+        // 댓글, 대댓글
+        Comment parentComment = Comment.ofWithIdeaAndCreator("댓글", null, idea, member);
+        Comment.ofWithIdeaAndCreator("대댓글", parentComment, idea, member);
+        // 좋아요
+        IdeaLike.ofWithIdeaAndMember(idea, member);
+        // 조회수
+        Hit.of(member, idea);
+        // 북마크
+        Bookmark.ofWithIdeaAndMember(idea, member);
 
         // when
         ideaService.deleteIdea(new AuthCredentials(member.getId()), idea.getId());

--- a/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
+++ b/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
@@ -265,11 +265,11 @@ class IdeaServiceTest {
         Region region = regionRepository.save(Region.from("BUSAN"));
         Member member = memberRepository.save(MemberFixture.createMember());
         Idea idea = ideaRepository.save(createValidIdea(region, member));
-        Comment parentComment = Comment.ofWithIdeaAndCreator("댓글", null, idea, member);
-        Comment.ofWithIdeaAndCreator("대댓글", parentComment, idea, member);
-        IdeaLike.ofWithIdeaAndMember(idea, member);
+        Comment parentComment = Comment.createCommentAssociatedWithIdeaAndCreator("댓글", null, idea, member);
+        Comment.createCommentAssociatedWithIdeaAndCreator("대댓글", parentComment, idea, member);
+        IdeaLike.createIdeaLikeAssociatedWithIdeaAndMember(idea, member);
         Hit.ofIdeaAndMember(idea, member);
-        Bookmark.ofWithIdeaAndMember(idea, member);
+        Bookmark.createBookmarkAssociatedWithIdeaAndMember(idea, member);
 
         // when
         ideaService.deleteIdea(new AuthCredentials(member.getId()), idea.getId());


### PR DESCRIPTION
## 📄 Summary
>
#60 해당 이슈에 관한 PR 입니다.
## 🙋🏻 More
> 
Cascade Remove 를 추가해 해결하였고, Test Case 로 (댓글, 대댓글), 좋아요, 조회, 북마크, 아이디어 분야,목적,스킬 등이 idea에 있는 상태에서 삭제를 진행하도록 했습니다.

그리고 정적 팩토리 메서드를 추가하였는데, 연관관계 매핑과 BookmarkID, IdeaLikeID 와 같은 복합키를 생성해주는 역할을 해주고 있어요.

추가적으로 드는 의문점은 BookmarkID,IdeaLikeID가 정말 필요한 컬럼이 맞을까요? 직접연관관계 매핑을 위해서 member, idea 가 존재하는 것 같긴하지만, 중복데이터의 느낌이 강해서요, 제 입장에서는 Auto-Increment ID(Identity) 값을 가지는게 나아보입니다.