### PR TITLE
[refactor] 게시글 수정시 동일한 항목이 여러개 생기는 것을 수정한다.

### DIFF
--- a/src/main/java/kr/co/conceptbe/idea/domain/Idea.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/Idea.java
@@ -131,9 +131,9 @@ public class Idea extends BaseTimeEntity {
         this.introduce = Introduce.from(introduce);
         this.cooperationWay = CooperationWay.from(cooperationWay);
         this.recruitmentPlace = recruitmentPlace;
-        this.branches = IdeaBranches.of(this, branches);
-        this.purposes = IdeaPurposes.of(this, purposes);
-        this.skillCategories = IdeaSkillCategories.of(this, skillCategories);
+        this.branches.update(this, branches);
+        this.purposes.update(this, purposes);
+        this.skillCategories.update(this, skillCategories);
     }
 
     public String getTitle() {

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaBranches.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaBranches.java
@@ -19,7 +19,11 @@ public class IdeaBranches {
 
     private static final int IDEA_BRANCHES_SIZE_LOWER_BOUND_INCLUSIVE = 1;
 
-    @OneToMany(mappedBy = "idea", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(
+        mappedBy = "idea",
+        orphanRemoval = true,
+        cascade = {CascadeType.PERSIST, CascadeType.REMOVE}
+    )
     private List<IdeaBranch> ideaBranches;
 
     private IdeaBranches(List<IdeaBranch> ideaBranches) {

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaBranches.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaBranches.java
@@ -6,6 +6,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import java.util.stream.Collectors;
 import kr.co.conceptbe.branch.domain.Branch;
 import kr.co.conceptbe.idea.domain.Idea;
 import kr.co.conceptbe.idea.domain.IdeaBranch;
@@ -35,9 +36,17 @@ public class IdeaBranches {
 
         List<IdeaBranch> ideaBranches = branches.stream()
             .map(branch -> IdeaBranch.of(idea, branch))
-            .toList();
+            .collect(Collectors.toList());
 
         return new IdeaBranches(ideaBranches);
+    }
+
+    public void update(Idea idea, List<Branch> branches) {
+        validateSize(branches);
+        ideaBranches.clear();
+        ideaBranches.addAll(branches.stream()
+            .map(branch -> IdeaBranch.of(idea, branch))
+            .collect(Collectors.toList()));
     }
 
     private static void validateSize(List<Branch> branches) {

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaPurposes.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaPurposes.java
@@ -20,7 +20,11 @@ public class IdeaPurposes {
 
     private static final int IDEA_PURPOSES_SIZE_LOWER_BOUND_INCLUSIVE = 1;
 
-    @OneToMany(mappedBy = "idea", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(
+        mappedBy = "idea",
+        orphanRemoval = true,
+        cascade = {CascadeType.PERSIST, CascadeType.REMOVE}
+    )
     private List<IdeaPurpose> ideaPurposes;
 
     private IdeaPurposes(List<IdeaPurpose> ideaPurposes) {

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaPurposes.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaPurposes.java
@@ -7,6 +7,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import java.util.stream.Collectors;
 import kr.co.conceptbe.idea.domain.Idea;
 import kr.co.conceptbe.idea.domain.IdeaPurpose;
 import kr.co.conceptbe.purpose.domain.Purpose;
@@ -36,9 +37,17 @@ public class IdeaPurposes {
 
         List<IdeaPurpose> ideaPurposes = purposes.stream()
             .map(purpose -> IdeaPurpose.of(idea, purpose))
-            .toList();
+            .collect(Collectors.toList());
 
         return new IdeaPurposes(ideaPurposes);
+    }
+
+    public void update(Idea idea, List<Purpose> purposes) {
+        validateSize(purposes);
+        ideaPurposes.clear();
+        ideaPurposes.addAll(purposes.stream()
+            .map(purpose -> IdeaPurpose.of(idea, purpose))
+            .collect(Collectors.toList()));
     }
 
     private static void validateSize(List<Purpose> purposes) {

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaSkillCategories.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaSkillCategories.java
@@ -19,7 +19,11 @@ public class IdeaSkillCategories {
 
     private static final int IDEA_SKILL_CATEGORIES_SIZE_UPPER_BOUND_INCLUSIVE = 10;
 
-    @OneToMany(mappedBy = "idea", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(
+        mappedBy = "idea",
+        orphanRemoval = true,
+        cascade = {CascadeType.PERSIST, CascadeType.REMOVE}
+    )
     private List<IdeaSkillCategory> ideaSkillCategories;
 
     private IdeaSkillCategories(List<IdeaSkillCategory> ideaSkillCategories) {

--- a/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaSkillCategories.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/vo/IdeaSkillCategories.java
@@ -6,6 +6,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import java.util.stream.Collectors;
 import kr.co.conceptbe.idea.domain.Idea;
 import kr.co.conceptbe.idea.domain.IdeaSkillCategory;
 import kr.co.conceptbe.skill.domain.SkillCategory;
@@ -35,9 +36,17 @@ public class IdeaSkillCategories {
 
         List<IdeaSkillCategory> ideaSkillCategories = skillCategories.stream()
             .map(skillCategory -> IdeaSkillCategory.of(idea, skillCategory))
-            .toList();
+            .collect(Collectors.toList());
 
         return new IdeaSkillCategories(ideaSkillCategories);
+    }
+
+    public void update(Idea idea, List<SkillCategory> skillCategories) {
+        validateSize(skillCategories);
+        ideaSkillCategories.clear();
+        ideaSkillCategories.addAll(skillCategories.stream()
+            .map(skillCategory -> IdeaSkillCategory.of(idea, skillCategory))
+            .collect(Collectors.toList()));
     }
 
     private static void validateSize(List<SkillCategory> skillCategories) {

--- a/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
+++ b/src/test/java/kr/co/conceptbe/idea/application/IdeaServiceTest.java
@@ -202,7 +202,7 @@ class IdeaServiceTest {
             () -> assertThat(ideaByFindById.getRecruitmentPlace()).isEqualTo(region.getName()),
             () -> assertThat(ideaByFindById.getBranches()).hasSize(VALID_BRANCH_COUNT),
             () -> assertThat(ideaByFindById.getPurposes()).hasSize(VALID_PURPOSE_COUNT),
-            () -> assertThat(ideaByFindById.getPurposes()).hasSize(VALID_PURPOSE_COUNT)
+            () -> assertThat(ideaByFindById.getSkillCategories()).hasSize(VALID_SKILL_COUNT)
         );
     }
 
@@ -265,7 +265,8 @@ class IdeaServiceTest {
         Region region = regionRepository.save(Region.from("BUSAN"));
         Member member = memberRepository.save(MemberFixture.createMember());
         Idea idea = ideaRepository.save(createValidIdea(region, member));
-        Comment parentComment = Comment.createCommentAssociatedWithIdeaAndCreator("댓글", null, idea, member);
+        Comment parentComment = Comment.createCommentAssociatedWithIdeaAndCreator("댓글", null, idea,
+            member);
         Comment.createCommentAssociatedWithIdeaAndCreator("대댓글", parentComment, idea, member);
         IdeaLike.createIdeaLikeAssociatedWithIdeaAndMember(idea, member);
         Hit.ofIdeaAndMember(idea, member);


### PR DESCRIPTION
## 📄 Summary
>
#62 해당 이슈를 처리하였습니다.

또한 이전에는 update 시 List를 다시 주입해주는 방식을 활용하였는데, 그것이 아닌 Clear 를 먼저 진행해주고 addAll 을 통해 데이터를 변경해주는 등, List를 활용하여 연산을 처리하였습니다.

이 과정에서 Stream.toList() 는 immutable 한 List 를 반환하기에 `Stream.collect(Collectors.toList());` 를 활용하였어요
## 🙋🏻 More
> 
