### PR TITLE
동일한 사용자가 게시글을 조회하더라도, 조회수가 올라가는 현상 해결 & 댓글, 게시글 조회시 memberId 추가

### DIFF
--- a/src/main/java/kr/co/conceptbe/comment/dto/CommentChildResponse.java
+++ b/src/main/java/kr/co/conceptbe/comment/dto/CommentChildResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 import kr.co.conceptbe.comment.Comment;
 
 public record CommentChildResponse(
+	Long memberId,
 	Long childCommentId,
 	String nickname,
 	String profileImageUrl,
@@ -19,6 +20,7 @@ public record CommentChildResponse(
 ) {
 	public static CommentChildResponse of(Comment comment, Long tokenMemberId) {
 		return new CommentChildResponse(
+			comment.getCreator().getId(),
 			comment.getId(),
 			comment.getCreator().getNickname(),
 			comment.getCreator().getProfileImageUrl(),

--- a/src/main/java/kr/co/conceptbe/comment/dto/CommentParentResponse.java
+++ b/src/main/java/kr/co/conceptbe/comment/dto/CommentParentResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 import kr.co.conceptbe.comment.Comment;
 
 public record CommentParentResponse (
+	Long memberId,
 	Long parentCommentId,
 	String nickname,
 	String profileImageUrl,
@@ -21,6 +22,7 @@ public record CommentParentResponse (
 ) {
 	public static CommentParentResponse of(Comment comment, Long tokenMemberId) {
 		return new CommentParentResponse(
+			comment.getCreator().getId(),
 			comment.getId(),
 			comment.getCreator().getNickname(),
 			comment.getCreator().getProfileImageUrl(),

--- a/src/main/java/kr/co/conceptbe/idea/application/IdeaService.java
+++ b/src/main/java/kr/co/conceptbe/idea/application/IdeaService.java
@@ -1,5 +1,6 @@
 package kr.co.conceptbe.idea.application;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -125,8 +126,12 @@ public class IdeaService {
         IdeaDetailResponse ideaDetailResponse = IdeaDetailResponse.of(tokenMemberId, idea);
 
         Member member = memberRepository.getById(tokenMemberId);
-        Hit hit = Hit.ofIdeaAndMember(idea, member);
-        hitRepository.save(hit);
+
+        Optional<Hit> hitOptional = hitRepository.findByMemberAndIdeaOrderByCreatedAtDesc(member, idea);
+        if (hitOptional.isEmpty() || hitOptional.get().isBeforeNow()) {
+            Hit hit = Hit.ofIdeaAndMember(idea, member);
+            hitRepository.save(hit);
+        }
 
         return ideaDetailResponse;
     }

--- a/src/main/java/kr/co/conceptbe/idea/domain/Hit.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/Hit.java
@@ -43,7 +43,7 @@ public class Hit extends BaseTimeEntity {
         return hit;
     }
 
-    public boolean isBeforeNow() {
+    public boolean isBeforeLocalDate() {
         return this.getCreatedAt().toLocalDate().isBefore(LocalDate.now());
     }
 }

--- a/src/main/java/kr/co/conceptbe/idea/domain/Hit.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/Hit.java
@@ -2,6 +2,8 @@ package kr.co.conceptbe.idea.domain;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import java.time.LocalDate;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -39,5 +41,9 @@ public class Hit extends BaseTimeEntity {
         Hit hit = new Hit(member, idea);
         idea.addHit(hit);
         return hit;
+    }
+
+    public boolean isBeforeNow() {
+        return this.getCreatedAt().toLocalDate().isBefore(LocalDate.now());
     }
 }

--- a/src/main/java/kr/co/conceptbe/idea/domain/IdeaLike.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/IdeaLike.java
@@ -31,15 +31,19 @@ public class IdeaLike extends BaseTimeEntity implements Serializable {
     @JoinColumn(name = "idea_id")
     private Idea idea;
 
-    public IdeaLike(IdeaLikeID ideaLikeID, Member member, Idea idea) {
+    private IdeaLike(IdeaLikeID ideaLikeID, Member member, Idea idea) {
         this.ideaLikeID = ideaLikeID;
         this.member = member;
         this.idea = idea;
     }
 
+    public static IdeaLike of(IdeaLikeID ideaLikeID, Member member, Idea idea) {
+        return new IdeaLike(ideaLikeID, member, idea);
+    }
+
     public static IdeaLike createIdeaLikeAssociatedWithIdeaAndMember(Idea idea, Member member) {
-        IdeaLikeID ideaLikeID = new IdeaLikeID(member.getId(), idea.getId());
-        IdeaLike ideaLike = new IdeaLike(ideaLikeID, member, idea);
+        IdeaLikeID ideaLikeID = IdeaLikeID.of(member, idea);
+        IdeaLike ideaLike = IdeaLike.of(ideaLikeID, member, idea);
         idea.addIdeaLikes(ideaLike);
         return ideaLike;
     }

--- a/src/main/java/kr/co/conceptbe/idea/domain/IdeaLikeID.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/IdeaLikeID.java
@@ -1,18 +1,29 @@
 package kr.co.conceptbe.idea.domain;
 
+import static lombok.AccessLevel.*;
+
 import java.io.Serializable;
 
 import jakarta.persistence.Embeddable;
+import kr.co.conceptbe.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter
 @Embeddable
+@NoArgsConstructor(access = PROTECTED)
 public class IdeaLikeID implements Serializable {
-
 	private Long memberId;
 	private Long ideaId;
+
+	private IdeaLikeID(Long memberId, Long ideaId) {
+		this.memberId = memberId;
+		this.ideaId = ideaId;
+	}
+
+	public static IdeaLikeID of(Member member, Idea idea) {
+		return new IdeaLikeID(member.getId(), idea.getId());
+	}
 }

--- a/src/main/java/kr/co/conceptbe/idea/domain/persistence/HitRepository.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/persistence/HitRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 import kr.co.conceptbe.idea.domain.Hit;
 
 @Repository
-public interface HitRepository extends JpaRepository<Hit, Long> {
+public interface HitRepository extends JpaRepository<Hit, Long>, HitRepositoryCustom {
 }

--- a/src/main/java/kr/co/conceptbe/idea/domain/persistence/HitRepository.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/persistence/HitRepository.java
@@ -1,10 +1,15 @@
 package kr.co.conceptbe.idea.domain.persistence;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import kr.co.conceptbe.idea.domain.Hit;
+import kr.co.conceptbe.idea.domain.Idea;
+import kr.co.conceptbe.member.domain.Member;
 
 @Repository
 public interface HitRepository extends JpaRepository<Hit, Long>, HitRepositoryCustom {
+	Optional<Hit> findFirstByMemberAndIdeaOrderByCreatedAtDesc(Member member, Idea idea);
 }

--- a/src/main/java/kr/co/conceptbe/idea/domain/persistence/HitRepositoryCustom.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/persistence/HitRepositoryCustom.java
@@ -1,0 +1,11 @@
+package kr.co.conceptbe.idea.domain.persistence;
+
+import java.util.Optional;
+
+import kr.co.conceptbe.idea.domain.Hit;
+import kr.co.conceptbe.idea.domain.Idea;
+import kr.co.conceptbe.member.domain.Member;
+
+public interface HitRepositoryCustom {
+	Optional<Hit> findByMemberAndIdeaOrderByCreatedAtDesc(Member member, Idea idea);
+}

--- a/src/main/java/kr/co/conceptbe/idea/domain/persistence/HitRepositoryCustomImpl.java
+++ b/src/main/java/kr/co/conceptbe/idea/domain/persistence/HitRepositoryCustomImpl.java
@@ -1,0 +1,30 @@
+package kr.co.conceptbe.idea.domain.persistence;
+
+import static kr.co.conceptbe.idea.domain.QHit.*;
+
+import java.util.Optional;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.co.conceptbe.idea.domain.Hit;
+import kr.co.conceptbe.idea.domain.Idea;
+import kr.co.conceptbe.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class HitRepositoryCustomImpl implements HitRepositoryCustom {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Optional<Hit> findByMemberAndIdeaOrderByCreatedAtDesc(Member member, Idea idea) {
+		return Optional.ofNullable(
+			jpaQueryFactory.selectFrom(hit)
+			.where(
+				hit.member.eq(member),
+				hit.idea.eq(idea)
+			)
+			.orderBy(hit.createdAt.desc())
+			.limit(1)
+			.fetchOne());
+	}
+}

--- a/src/main/java/kr/co/conceptbe/idea/dto/IdeaDetailResponse.java
+++ b/src/main/java/kr/co/conceptbe/idea/dto/IdeaDetailResponse.java
@@ -7,6 +7,7 @@ import kr.co.conceptbe.comment.Comment;
 import kr.co.conceptbe.idea.domain.Idea;
 
 public record IdeaDetailResponse (
+	Long memberId,
 	String imageUrl,
 	String nickname,
 	List<String> skillList,
@@ -28,6 +29,7 @@ public record IdeaDetailResponse (
 ) {
 	public static IdeaDetailResponse of(Long tokenMemberId, Idea idea) {
 		return new IdeaDetailResponse(
+			idea.getCreator().getId(),
 			idea.getCreator().getProfileImageUrl(),
 			idea.getCreator().getNickname(),
 			idea.getCreator().getSkills().getValues().stream().map(e -> e.getSkillCategory().getName()).toList(),

--- a/src/test/java/kr/co/conceptbe/idea/persistence/IdeaRepositoryTest.java
+++ b/src/test/java/kr/co/conceptbe/idea/persistence/IdeaRepositoryTest.java
@@ -172,8 +172,8 @@ class IdeaRepositoryTest {
             region, List.of(branch), List.of(purpose),
             List.of(skillCategory), member
         ));
-        ideaLikesRepository.save(new IdeaLike(
-            new IdeaLikeID(member.getId(), result.getId()), member, result
+        ideaLikesRepository.save(IdeaLike.of(
+            IdeaLikeID.of(member, result), member, result
         ));
 
         // when
@@ -210,8 +210,8 @@ class IdeaRepositoryTest {
             region, List.of(branch1, branch3), List.of(purpose),
             List.of(skillCategory1, skillCategory2), member
         ));
-        ideaLikesRepository.save(new IdeaLike(
-            new IdeaLikeID(member.getId(), result1.getId()), member, result1
+        ideaLikesRepository.save(IdeaLike.of(
+            IdeaLikeID.of(member, result1), member, result1
         ));
         Idea notInquiry1 = ideaRepository.save(IdeaFixture.createIdea(
             region, List.of(branch2), List.of(purpose),


### PR DESCRIPTION
## 📄 Summary
>
Member와 Idea로 Hit를 조회 후 비어있거나, 오늘이 아닌경우에 조회수 증가를 할 수 있도록 해보았습니다.
* 후자가 불필요한 것 같다면 지우겠습니다

프론트 요청사항 : 댓글, 게시글 memberId 추가하기
## 🙋🏻 More
> 
