### PR TITLE
refactor : 멤버 닉네임 중복 검사 메소드 수정

### DIFF
--- a/src/main/java/kr/co/conceptbe/member/application/MemberService.java
+++ b/src/main/java/kr/co/conceptbe/member/application/MemberService.java
@@ -17,6 +17,7 @@ import kr.co.conceptbe.member.application.dto.MemberIdeaResponseOption;
 import kr.co.conceptbe.member.application.dto.MemberProfileSkillResponse;
 import kr.co.conceptbe.member.domain.Member;
 import kr.co.conceptbe.member.domain.MemberPurpose;
+import kr.co.conceptbe.member.domain.vo.Nickname;
 import kr.co.conceptbe.member.exception.NotOwnerException;
 import kr.co.conceptbe.member.persistence.MemberRepository;
 import kr.co.conceptbe.purpose.domain.Purpose;
@@ -41,7 +42,7 @@ public class MemberService {
     private final PurposeRepository purposeRepository;
 
     public boolean validateDuplicatedNickName(String nickname) {
-        return !memberRepository.existsByNickname(nickname);
+        return !memberRepository.existsByNickname(Nickname.from(nickname));
     }
 
     public GetMemberProfileResponse getMemberProfileBy(AuthCredentials authCredentials, Long id) {

--- a/src/main/java/kr/co/conceptbe/member/persistence/MemberRepository.java
+++ b/src/main/java/kr/co/conceptbe/member/persistence/MemberRepository.java
@@ -3,6 +3,7 @@ package kr.co.conceptbe.member.persistence;
 import java.util.Optional;
 import kr.co.conceptbe.member.domain.Member;
 import kr.co.conceptbe.member.domain.OauthId;
+import kr.co.conceptbe.member.domain.vo.Nickname;
 import kr.co.conceptbe.member.exception.NotFoundMemberException;
 import kr.co.conceptbe.member.exception.NotFoundOauthMemberException;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,5 +24,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             () -> new NotFoundMemberException(memberId));
     }
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNickname(Nickname nickname);
 }


### PR DESCRIPTION
## 📄 Summary
>  existsByNickname(String nickname) 에서 existsByNickname(Nickname nickname) 로 변경하였습니다.

## 🙋🏻 More
> 
